### PR TITLE
Lastpass Importer

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/buttercup-pw/buttercup-importer#readme",
   "dependencies": {
     "buttercup": "~0.38.1",
+    "csvjson": "^4.3.3",
     "is-dir": "~1.0.0",
     "kdbxweb": "~1.0.1",
     "pify": "~2.3.0",

--- a/source/importers/LastPassImporter.js
+++ b/source/importers/LastPassImporter.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+
+const pify = require("pify");
+const { Archive } = require("buttercup");
+const csvjson = require("csvjson");
+
+const defaultGroup = "General";
+
+/**
+ * Import an exported LastPass CSV archive
+ * @param {String} lpcsvPath The path to the LastPass CSV file
+ * @returns {Promise.<Archive>} A promise that resolves with the imported archive
+ */
+const importFromLastPass = lpcsvPath => {
+	const groups = {};
+
+	return pify(fs.readFile)(lpcsvPath, "utf8")
+		.then(contents => {
+			const archive = new Archive();
+			csvjson.toObject(contents).forEach(lastpassItem => {
+				const groupName = lastpassItem.grouping || defaultGroup;
+				const group = groups[groupName] || (groups[groupName] = archive.createGroup(groupName));
+				group
+					.createEntry(lastpassItem.name)
+					.setProperty("username", lastpassItem.username)
+					.setProperty("password", lastpassItem.password)
+					.setMeta("URL", lastpassItem.url)
+					.setMeta("Notes", lastpassItem.extra);
+			});
+
+			return archive;
+		});
+};
+
+module.exports = importFromLastPass;

--- a/source/index.js
+++ b/source/index.js
@@ -2,6 +2,7 @@
 
 const KDBXImporter = require("./importers/KDBXImporter.js");
 const OnePasswordImporter = require("./importers/1PasswordImporter.js");
+const importFromLastPass = require("./importers/LastPassImporter.js");
 
 module.exports = {
 
@@ -24,6 +25,13 @@ module.exports = {
 	importFromKDBX: function(kdbxFile, password) {
 		var importer = new KDBXImporter(kdbxFile);
 		return importer.export(password);
-	}
+	},
+
+	/**
+	 * Import an exported LastPass CSV archive
+	 * @param {String} lpcsvPath The path to the LastPass CSV file
+	 * @returns {Promise.<Archive>} A promise that resolves with the imported archive
+	 */
+	importFromLastPass
 
 };

--- a/tests/cli/LastPassTests.js
+++ b/tests/cli/LastPassTests.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const path = require("path");
+
+const { importFromLastPass } = require("../../source/index.js");
+const { Archive } = require("buttercup");
+
+const lpcsvPath = path.resolve(__dirname, "../resources/lastpass.csv");
+
+module.exports = {
+  export: {
+    createsArchive: test => {
+      importFromLastPass(lpcsvPath).then(archive => {
+        test.ok(archive instanceof Archive, "Archive should be a Buttercup archive instance");
+        test.done();
+      });
+    },
+    containsGroups: test => {
+      importFromLastPass(lpcsvPath).then(archive => {
+        const groups = archive.toObject().groups.map(g => g.title);
+        test.ok(groups.length === 2, "There should be two groups");
+        test.ok(groups.includes("General"), "General Group should exist");
+        test.ok(groups.includes("FooBar"), "FooBar Group should exist");
+        test.done();
+      });
+    },
+    containsEntries: test => {
+      importFromLastPass(lpcsvPath).then(archive => {
+        const entries = archive.toObject().groups.map(g => g.entries).reduce((a,b) => a.concat(b));
+        test.ok(entries.length === 3, "There should be three entries");
+        test.ok(entries[0].meta.URL === "https://foo.com", "meta.URL is set correctly");
+        test.ok(entries[0].meta.Notes === "This is extra data", "meta.Notes is set correctly");
+        test.ok(entries[0].properties.password === "thisisasecret", "properties.password is set correctly");
+        test.ok(entries[0].properties.title === "foo.com", "properties.title is set correctly");
+        test.ok(entries[0].properties.username === "user@foo.com", "properties.username is set correctly");
+        test.done();
+      });
+    }
+  }
+};

--- a/tests/resources/lastpass.csv
+++ b/tests/resources/lastpass.csv
@@ -1,0 +1,4 @@
+url,username,password,extra,name,grouping,fav
+https://foo.com,user@foo.com,thisisasecret,This is extra data,foo.com,FooBar,0
+https://bar.com,user@bar.com,thisisasecret,This is extra data,bar.com,FooBar,0
+https://fizz.com,user@fizz.com,thisisasecret,This is extra data,fizz.com,,0


### PR DESCRIPTION
Imports data from a .csv file exported via LastPass.

Maps LastPass groups over to Buttercup. Any LastPass items not in a group will be added to a "General" Buttercup group.

Preserves LastPass url under "URL" Buttercup meta.
Preserves LastPass notes under "Notes" Buttercup meta.

Tests included 🍻