### PR TITLE
Check LastPass notes exist before trying to import them

### DIFF
--- a/source/importers/LastPassImporter.js
+++ b/source/importers/LastPassImporter.js
@@ -23,12 +23,14 @@ const importFromLastPass = lpcsvPath => {
 			csvjson.toObject(contents).forEach(lastpassItem => {
 				const groupName = lastpassItem.grouping || defaultGroup;
 				const group = groups[groupName] || (groups[groupName] = archive.createGroup(groupName));
-				group
+				const entry = group
 					.createEntry(lastpassItem.name)
 					.setProperty("username", lastpassItem.username)
 					.setProperty("password", lastpassItem.password)
-					.setMeta("URL", lastpassItem.url)
-					.setMeta("Notes", lastpassItem.extra);
+					.setMeta("URL", lastpassItem.url);
+				if(lastpassItem.extra) {
+					entry.setMeta("Notes", lastpassItem.extra);
+				}
 			});
 
 			return archive;

--- a/tests/cli/LastPassTests.js
+++ b/tests/cli/LastPassTests.js
@@ -35,6 +35,14 @@ module.exports = {
         test.ok(entries[0].properties.username === "user@foo.com", "properties.username is set correctly");
         test.done();
       });
+    },
+    doesntImportEmptyNotes: test => {
+      importFromLastPass(lpcsvPath).then(archive => {
+        const entries = archive.toObject().groups.map(g => g.entries).reduce((a,b) => a.concat(b));
+        test.ok(entries[1].meta.Notes === undefined);
+        test.ok(entries[2].meta.Notes === undefined);
+        test.done();
+      });
     }
   }
 };

--- a/tests/resources/lastpass.csv
+++ b/tests/resources/lastpass.csv
@@ -1,4 +1,4 @@
 url,username,password,extra,name,grouping,fav
 https://foo.com,user@foo.com,thisisasecret,This is extra data,foo.com,FooBar,0
-https://bar.com,user@bar.com,thisisasecret,This is extra data,bar.com,FooBar,0
-https://fizz.com,user@fizz.com,thisisasecret,This is extra data,fizz.com,,0
+https://bar.com,user@bar.com,thisisasecret,,bar.com,FooBar,0
+https://fizz.com,user@fizz.com,thisisasecret,,fizz.com,,0


### PR DESCRIPTION
Sorry, just going through my archive and noticed a bug. If you have a LastPass entry without a note it adds the note as an empty string. This then get's rendered in the app as the string: "utf8+base64:".

This PR fixes that by explicitly checking if a note exists before creating the meta value.

Also added a test.

Sorry 😂