### PR TITLE
Include the Bitwarden and 1password fixed in a new version: 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Buttercup importer changelog
 
+## v3.0.2
+_2020-10-26_
+ * **Bugfix**
+   * Preventing undefined entry metadata for Bitwarden and 1Password imports
+
 ## v3.0.1
 _2020-07-12_
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buttercup/importer",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Buttercup archive importer for other password manager archives",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- Updated the `CHANGELOG` and `package.json` file to version `3.0.2`
- Added an new version tag, but not sure if this is passed in the pull request.

After the version has been updated, I'll do the same for `buttercup-desktop` to include this latest version.
