### PR TITLE
Do Not Import Empty Custom Fields from Buttercup CSV

### DIFF
--- a/source/importers/ButtercupCSVImporter.js
+++ b/source/importers/ButtercupCSVImporter.js
@@ -51,6 +51,7 @@ class ButtercupCSVImporter {
                     Object.keys(bcupItem)
                         .filter(key => /^\!.+/.test(key) === false)
                         .filter(key => NON_COPY_KEYS.indexOf(key) === -1)
+                        .filter(key => bcupItem[key])
                         .forEach(key => {
                             entry.setProperty(key, bcupItem[key]);
                         });

--- a/test/specs/importers/ButtercupCSVImporter.spec.js
+++ b/test/specs/importers/ButtercupCSVImporter.spec.js
@@ -15,7 +15,8 @@ describe("ButtercupCSVImporter", function() {
             .setProperty("username", "user")
             .setProperty("password", "pass")
             .setProperty("URL", "http://test.com")
-            .setProperty("secret", "value");
+            .setProperty("secret", "value")
+            .setProperty("empty", "");
         group.createGroup("Test Child Group");
         return exportVaultToCSV(vault)
             .then(csv => {
@@ -56,5 +57,6 @@ describe("ButtercupCSVImporter", function() {
         expect(entry).to.be.an.instanceOf(Entry);
         expect(entry.getProperty("username")).to.equal("user");
         expect(entry.getProperty("password")).to.equal("pass");
+        expect(entry.getProperty("empty")).to.be.undefined;
     });
 });


### PR DESCRIPTION
Fixes #69

When a Buttercup CSV with extra properties is saved, every possible extra property key is imported into all entries, even if the entry doesn't define the extra property.

This PR adds a check when importing the Buttercup CSV to ignore extra properties that don't have a value. This prevents empty extra properties from showing up in the UI after an import.